### PR TITLE
Reset all arrays in clearCanvas

### DIFF
--- a/telepict/static/js/drawingCanvas.js
+++ b/telepict/static/js/drawingCanvas.js
@@ -92,6 +92,8 @@ function redraw() {
 function clearCanvas() {
   clickX = new Array();
   clickY = new Array();
+  clickColors = new Array();
+  clickSizes = new Array();
   clickDrag = new Array();
   redraw();
 }


### PR DESCRIPTION
This fixes changing the color and line weight after clicking the clear button